### PR TITLE
Windows-CLI fix the 'input line is too long' error

### DIFF
--- a/deployment/distribution/build.gradle.kts
+++ b/deployment/distribution/build.gradle.kts
@@ -58,6 +58,7 @@ tasks {
     }
 
     "startScripts"(CreateStartScripts::class) {
+        classpath = files(System.getProperty("app.home") + "/lib/*")
         doLast {
             unixScript.let {
                 it.writeText(it.readText().replace("SAMLCTK_APP_HOME", "\$APP_HOME"))


### PR DESCRIPTION
### Description of the Change
Fix the windows 'input line is too long' CLI issue.

### Checklist:
- [ ] Unit Tests Added/Modified
