### PR TITLE
Disabled email name id verification

### DIFF
--- a/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/SamlDefinedIdentifiersVerifier.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/verification/core/SamlDefinedIdentifiersVerifier.kt
@@ -6,6 +6,7 @@ http://www.gnu.org/licenses/lgpl.html
 */
 package org.codice.compliance.verification.core
 
+import org.codice.compliance.Common.Companion.idpMetadataObject
 import org.codice.compliance.SAMLComplianceException
 import org.codice.compliance.SAMLCore_8_2_2_a
 import org.codice.compliance.SAMLCore_8_2_3_a
@@ -26,7 +27,6 @@ import org.codice.compliance.utils.PERSISTENT_ID
 import org.codice.compliance.utils.SP_NAME_QUALIFIER
 import org.codice.compliance.utils.TRANSIENT_ID
 import org.codice.compliance.utils.TestCommon.Companion.currentSPIssuer
-import org.codice.compliance.Common.Companion.idpMetadataObject
 import org.w3c.dom.DOMException
 import org.w3c.dom.Node
 import java.net.URI
@@ -64,7 +64,9 @@ internal class SamlDefinedIdentifiersVerifier(val node: Node) {
     /** 8 SAML-Defined Identifiers */
     fun verify() {
         verifyAttributeNameFormatIdentifiers()
-        verifyEmailAddressIdentifier()
+        // Disabled email verification since it's not a requirement.
+        // Should be re-enabled once the CTK supports categorization of tests.
+        // verifyEmailAddressIdentifier()
         verifyPersistentIdentifiers()
         verifyTransientIdentifiers()
         verifyEntityIdentifiers()
@@ -161,7 +163,7 @@ internal class SamlDefinedIdentifiersVerifier(val node: Node) {
                                     SAMLCore_8_3_7_c,
                                     message = "The Persistent ID's NameQualifier " +
                                             "[$nameQualifier] is not equal to " +
-                                            "${idpMetadataObject.entityId}",
+                                            idpMetadataObject.entityId,
                                     node = it)
                     }
 

--- a/ctk/common/src/test/kotlin/org/codice/compilance/verification/core/SamlDefinedIdentifiersVerifierSpec.kt
+++ b/ctk/common/src/test/kotlin/org/codice/compilance/verification/core/SamlDefinedIdentifiersVerifierSpec.kt
@@ -131,7 +131,7 @@ class SamlDefinedIdentifiersVerifierSpec : StringSpec() {
         }
 
         /* 8.3.2 Email Address */
-        "valid Email name identifier" {
+        "valid Email name identifier".config(enabled = false) {
             createResponse(
                     identifierValue = "example-email@domain.com",
                     identifierFormat = NAME_ID_FORMAT_EMAIL).let {
@@ -139,7 +139,7 @@ class SamlDefinedIdentifiersVerifierSpec : StringSpec() {
             }
         }
 
-        "invalid Email name identifier (multiple '@'s)" {
+        "invalid Email name identifier (multiple '@'s)".config(enabled = false) {
             createResponse(
                     identifierValue = "example@email@domain.com",
                     identifierFormat = NAME_ID_FORMAT_EMAIL).let {
@@ -149,7 +149,7 @@ class SamlDefinedIdentifiersVerifierSpec : StringSpec() {
             }
         }
 
-        "invalid Email name identifier (no '@')" {
+        "invalid Email name identifier (no '@')".config(enabled = false) {
             createResponse(
                     identifierValue = "example-email.domain.com",
                     identifierFormat = NAME_ID_FORMAT_EMAIL).let {
@@ -159,7 +159,7 @@ class SamlDefinedIdentifiersVerifierSpec : StringSpec() {
             }
         }
 
-        "invalid Email name identifier (no '.com')" {
+        "invalid Email name identifier (no '.com')".config(enabled = false) {
             createResponse(
                     identifierValue = "example-email@domain",
                     identifierFormat = NAME_ID_FORMAT_EMAIL).let {
@@ -169,7 +169,7 @@ class SamlDefinedIdentifiersVerifierSpec : StringSpec() {
             }
         }
 
-        "invalid Email name identifier (end with '.')" {
+        "invalid Email name identifier (end with '.')".config(enabled = false) {
             createResponse(
                     identifierValue = "example-email@domain.",
                     identifierFormat = NAME_ID_FORMAT_EMAIL).let {
@@ -179,7 +179,7 @@ class SamlDefinedIdentifiersVerifierSpec : StringSpec() {
             }
         }
 
-        "invalid Email name identifier (single word)" {
+        "invalid Email name identifier (single word)".config(enabled = false) {
             createResponse(
                     identifierValue = "exampleemaildomaincom",
                     identifierFormat = NAME_ID_FORMAT_EMAIL).let {
@@ -189,7 +189,7 @@ class SamlDefinedIdentifiersVerifierSpec : StringSpec() {
             }
         }
 
-        "invalid Email name identifier (whitespace)" {
+        "invalid Email name identifier (whitespace)".config(enabled = false) {
             createResponse(
                     identifierValue = "example email@domain.com",
                     identifierFormat = NAME_ID_FORMAT_EMAIL).let {
@@ -199,7 +199,7 @@ class SamlDefinedIdentifiersVerifierSpec : StringSpec() {
             }
         }
 
-        "invalid Email name identifier (invalid characters)" {
+        "invalid Email name identifier (invalid characters)".config(enabled = false) {
             createResponse(
                     identifierValue = "example:email@domain.com",
                     identifierFormat = NAME_ID_FORMAT_EMAIL).let {
@@ -209,7 +209,7 @@ class SamlDefinedIdentifiersVerifierSpec : StringSpec() {
             }
         }
 
-        "invalid Email name identifier (comment)" {
+        "invalid Email name identifier (comment)".config(enabled = false) {
             createResponse(
                     identifierValue = "example.email@domain.com(comment)",
                     identifierFormat = NAME_ID_FORMAT_EMAIL).let {
@@ -219,7 +219,7 @@ class SamlDefinedIdentifiersVerifierSpec : StringSpec() {
             }
         }
 
-        "invalid Email name identifier (surrounded by '<' and '>')" {
+        "invalid Email name identifier (surrounded by '<' and '>')".config(enabled = false) {
             createResponse(
                     identifierValue = "&lt;example.email@domain.com&gt;",
                     identifierFormat = NAME_ID_FORMAT_EMAIL).let {

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/PostSSOTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/PostSSOTest.kt
@@ -109,7 +109,7 @@ class PostSSOTest : StringSpec() {
             }
         }
 
-        "POST AuthnRequest With Email NameIDPolicy Format Test" {
+        "POST AuthnRequest With Email NameIDPolicy Format Test".config(enabled = false) {
             val authnRequest = createDefaultAuthnRequest(HTTP_POST).apply {
                 nameIDPolicy = NameIDPolicyBuilder().buildObject().apply {
                     format = SAML2Constants.NAMEID_FORMAT_EMAIL_ADDRESS

--- a/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/RedirectSSOTest.kt
+++ b/ctk/idp/src/main/kotlin/org/codice/compliance/web/sso/RedirectSSOTest.kt
@@ -149,7 +149,7 @@ class RedirectSSOTest : StringSpec() {
             }
         }
 
-        "Redirect AuthnRequest With Email NameID Format Test" {
+        "Redirect AuthnRequest With Email NameID Format Test".config(enabled = false) {
             val authnRequest = createDefaultAuthnRequest(HTTP_REDIRECT).apply {
                 nameIDPolicy = NameIDPolicyBuilder().buildObject().apply {
                     format = SAML2Constants.NAMEID_FORMAT_EMAIL_ADDRESS


### PR DESCRIPTION
### Description of the Change
Disabled email name id verification because it isn't a MUST.

### SAML V2.0 Specification Quote
```
CORE 8.3.2 Email Address
URI: urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress
Indicates that the content of the element is in the form of an email address, 
specifically "addr-spec" as defined in IETF RFC 2822 Section 3.4.1. An addr-spec 
has the form local-part@domain. Note that an addr-spec has no phrase (such as a 
common name) before it, has no comment (text surrounded in parentheses) after it, 
and is not surrounded by "<" and ">".
```

### Verification Process
Successful CI build

### Checklist:
- [x] Unit Tests Added/Modified
