### PR TITLE
MAINT - Upgrades Kotlin to version 1.2.70

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -11,7 +11,7 @@ object Versions {
 
     const val javaTarget = "1.8"
 
-    const val kotlin = "1.2.61"
+    const val kotlin = "1.2.70"
     const val gradleDocker = "3.2.4"
     const val kotlinTest = "3.1.9"
     const val restAssured = "3.1.1"


### PR DESCRIPTION
### Description of the Change
Framework upgrade

Fixes: #202 

### Checklist:
- [ ] Unit Tests Added/Modified
