### PR TITLE
MAINT - Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Run the executable `samlconf` (*NIX) or `samlconf.bat` (Windows).
 The `samlconf` script may take the following parameters:
 
     NAME
-           samlconf - Runs the SAML Conformance Tests against an IdP
+           SamlConf - Runs the SAML Conformance Tests against an IdP
 
     SYNOPSIS
            samlconf [arguments ...]
@@ -57,18 +57,21 @@ The `samlconf` script may take the following parameters:
            not provided, the default values will use Distributed Data Framework (DDF)'s parameters.
 
     OPTIONS
-           -debug
-                Enables debug mode which enables more logging. This mode is off by default.
-
-           -ddf
+           -ddf, --ddf
                 Runs the DDF profile. If provided runs the optional SAML V2.0 Standard
                 Specification rules required by DDF.
 
-           -i path
+           -debug, --debug
+                Enables debug mode which enables more logging. This mode is off by default.
+
+           -h, --help
+		        Displays the possible arguments.
+
+           -i path, --implementation=path
                 The path to the directory containing the implementation's plugin and metadata.
                 The default value is /implementations/ddf.
 
-           -l
+           -l, --lenient
                 When an error occurs, the SAML V2.0 Standard Specification requires an IdP to
                 respond with a 200 HTTP status code and a valid SAML response containing an
                 error <StatusCode>.
@@ -77,7 +80,7 @@ The `samlconf` script may take the following parameters:
                 If it is not given, this test kit will only verify that a valid SAML error
                 response is returned.
 
-           -u username:password
+           -u username:password, --userLogin=username:password
                 The username and password to use when logging in.
                 The default value is admin:admin.
 

--- a/ctk/common/src/main/kotlin/org/codice/compliance/utils/RestAssuredExtensions.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/utils/RestAssuredExtensions.kt
@@ -179,8 +179,8 @@ fun Node.isNotHidden(): Boolean {
  * false if it does.
  */
 fun Node.hasNoAttributeWithNameAndValue(
-        attributeName: String,
-        expectedValue: String
+    attributeName: String,
+    expectedValue: String
 ): Boolean {
     return expectedValue != this.getAttribute(attributeName)
 }

--- a/ctk/common/src/main/kotlin/org/codice/compliance/utils/RestAssuredExtensions.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/utils/RestAssuredExtensions.kt
@@ -19,17 +19,35 @@ import org.codice.security.saml.SamlProtocol
 
 /** Response extension functions **/
 private const val BINDING_UNSUPPORTED_MESSAGE = "Binding is not currently supported."
+private const val EMPTY_BODY_MESSAGE =
+        "The binding in use is not Redirect and the response body is empty."
 
+/**
+ * Determines the {@code Response} binding.
+ *
+ * @return the {@code SamlProtocol.Binding} representation of the {@code Response} binding
+ * @throws IllegalArgumentException if the bindings is not redirect and the {@code Response}
+ * has an empty body
+ * @throws UnsupportedOperationException if the binding cannot be determined
+ */
 fun Response.determineBinding(): SamlProtocol.Binding {
     return with(this) {
         when {
-            isPostBinding() -> SamlProtocol.Binding.HTTP_POST
             isRedirectBinding() -> SamlProtocol.Binding.HTTP_REDIRECT
+            // Verify that the body is not empty
+            body.asString().isBlank() -> throw IllegalArgumentException(EMPTY_BODY_MESSAGE)
+            isPostBinding() -> SamlProtocol.Binding.HTTP_POST
             else -> throw UnsupportedOperationException(BINDING_UNSUPPORTED_MESSAGE)
         }
     }
 }
 
+/**
+ * Verifies that the {@code Response} is not an error response and finds the {@code BindingVerifier}
+ * that matches the {@code Response} binding.
+ *
+ * @return the verifier which corresponds to the response's binding.
+ */
 fun Response.getBindingVerifier(): BindingVerifier {
     // checking the status code of the response before attempting to determine the binding
     // because the binding cannot be determined from an http error response
@@ -42,6 +60,11 @@ fun Response.getBindingVerifier(): BindingVerifier {
     }
 }
 
+/**
+ * Finds the assertion consumer service url of the SAML Request or Response
+ *
+ * @return the assertion consumer service url
+ */
 fun Response.getLocation(): String? {
     return when (this.determineBinding()) {
         SamlProtocol.Binding.HTTP_REDIRECT -> {
@@ -56,6 +79,11 @@ fun Response.getLocation(): String? {
     }
 }
 
+/**
+ * Extracts the SAMLRequest or SAMLResponse from the given {@code Response} body
+ *
+ * @return the {@code Node} containing the SAMLRequest or SAMLResponse
+ */
 fun Response.extractSamlMessageForm(): Node? {
     return this
             .then()
@@ -67,12 +95,18 @@ fun Response.extractSamlMessageForm(): Node? {
                         .any { formControl ->
                             SAML_RESPONSE.equals(formControl.getAttribute(NAME),
                                     ignoreCase = true) ||
-                                SAML_REQUEST.equals(formControl.getAttribute(NAME),
-                                    ignoreCase = true)
+                                    SAML_REQUEST.equals(formControl.getAttribute(NAME),
+                                            ignoreCase = true)
                         }
             }
 }
 
+/**
+ * Finds the immediate children of a {@code Node}.
+ *
+ * @param name - Optional element name to match.
+ * @return List of child {@code Nodes}.
+ */
 private fun Node.childrenSearch(name: String? = null): List<Node> {
     val predicate: (Node) -> Boolean =
             if (name == null) {
@@ -103,17 +137,26 @@ fun Node.recursiveChildren(name: String? = null): List<Node> {
     return nodes
 }
 
+/**
+ * @return true if the SAML message was successfully extracted or false otherwise
+ */
 private fun Response.isPostBinding(): Boolean {
     return this.extractSamlMessageForm() != null
 }
 
+/**
+ * @return true if the Location header conatins a SAMLRequest or a SAMLResponse
+ */
 private fun Response.isRedirectBinding(): Boolean {
     return this.getHeader(LOCATION)?.contains("$SAML_RESPONSE=") == true ||
-        this.getHeader(LOCATION)?.contains("$SAML_REQUEST=") == true
+            this.getHeader(LOCATION)?.contains("$SAML_REQUEST=") == true
 }
 
 /** Node extension functions **/
 
+/**
+ * @return the value of the given {@code Node}
+ */
 fun Node.extractValue(): String? {
     if (!this.value().isNullOrEmpty()) {
         return this.value()
@@ -124,13 +167,20 @@ fun Node.extractValue(): String? {
     } else null
 }
 
+/**
+ * @return true if the {@code Node}'s type is hidden or false otherwise
+ */
 fun Node.isNotHidden(): Boolean {
     return !HIDDEN.equals(this.getAttribute(TYPE_LOWER), ignoreCase = true)
 }
 
+/**
+ * @return true if the {@code Node} doesn't have an attribute matching the given name and value or
+ * false if it does.
+ */
 fun Node.hasNoAttributeWithNameAndValue(
-    attributeName: String,
-    expectedValue: String
+        attributeName: String,
+        expectedValue: String
 ): Boolean {
     return expectedValue != this.getAttribute(attributeName)
 }

--- a/deployment/distribution/src/main/kotlin/org/codice/ctk/Command.kt
+++ b/deployment/distribution/src/main/kotlin/org/codice/ctk/Command.kt
@@ -14,141 +14,84 @@ import org.codice.compliance.LENIENT_ERROR_VERIFICATION
 import org.codice.compliance.RUN_DDF_PROFILE
 import org.codice.compliance.TEST_SP_METADATA_PROPERTY
 import org.codice.compliance.USER_LOGIN
-import org.codice.compliance.web.slo.PostSLOTest
-import org.codice.compliance.web.slo.RedirectSLOTest
-import org.codice.compliance.web.slo.error.PostSLOErrorTest
-import org.codice.compliance.web.slo.error.RedirectSLOErrorTest
-import org.codice.compliance.web.sso.PostSSOTest
-import org.codice.compliance.web.sso.RedirectSSOTest
-import org.codice.compliance.web.sso.error.PostSSOErrorTest
-import org.codice.compliance.web.sso.error.RedirectSSOErrorTest
-import org.codice.ctk.Runner.Companion.SLO_BASIC_TESTS
-import org.codice.ctk.Runner.Companion.SLO_ERROR_TESTS
-import org.codice.ctk.Runner.Companion.SSO_BASIC_TESTS
-import org.codice.ctk.Runner.Companion.SSO_ERROR_TESTS
-import org.fusesource.jansi.Ansi.ansi
-import org.junit.platform.engine.TestExecutionResult
-import org.junit.platform.engine.discovery.DiscoverySelectors.selectClass
-import org.junit.platform.launcher.TestExecutionListener
-import org.junit.platform.launcher.TestIdentifier
-import org.junit.platform.launcher.TestPlan
-import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder
-import org.junit.platform.launcher.core.LauncherFactory
-import org.junit.platform.launcher.listeners.SummaryGeneratingListener
 import us.jimschubert.kopper.Parser
 import java.io.File
-import java.io.PrintWriter
 
-private class Runner {
-    companion object {
-        val SSO_BASIC_TESTS = arrayOf(selectClass(PostSSOTest::class.java),
-                selectClass(RedirectSSOTest::class.java))
-        val SSO_ERROR_TESTS = arrayOf(selectClass(RedirectSSOErrorTest::class.java),
-                selectClass(PostSSOErrorTest::class.java))
-        val SLO_BASIC_TESTS = arrayOf(selectClass(PostSLOTest::class.java),
-                selectClass(RedirectSLOTest::class.java))
-        val SLO_ERROR_TESTS = arrayOf(selectClass(PostSLOErrorTest::class.java),
-                selectClass(RedirectSLOErrorTest::class.java))
-    }
-}
-
+@Suppress("StringLiteralDuplication")
 fun main(args: Array<String>) {
     val samlDist = System.getProperty("app.home")
     requireNotNull(samlDist) { "app.home System property must be set" }
 
+    val defaultImplPath = "$samlDist${File.separator}$DEFAULT_IMPLEMENTATION_PATH"
+    val ctkMetadataPath = "$samlDist${File.separator}conf${File.separator}samlconf-sp-metadata.xml"
+
     val parser = createParser()
     val arguments = parser.parse(args)
 
-    val implementationPath = arguments.option("i")
-            ?: "$samlDist${File.separator}$DEFAULT_IMPLEMENTATION_PATH"
-    val userLogin = arguments.option("i") ?: "admin:admin"
+    val implementationPath = arguments.option("i") ?: defaultImplPath
+    val userLogin = arguments.option("u") ?: "admin:admin"
+
+    if (arguments.flag("help")) {
+        println(parser.printHelp())
+        return
+    }
 
     System.setProperty(IMPLEMENTATION_PATH, implementationPath)
     System.setProperty(USER_LOGIN, userLogin)
-    System.setProperty(TEST_SP_METADATA_PROPERTY, "$samlDist${File.separator}conf" +
-            "${File.separator}samlconf-sp-metadata.xml")
+    System.setProperty(TEST_SP_METADATA_PROPERTY, ctkMetadataPath)
     System.setProperty(LENIENT_ERROR_VERIFICATION, arguments.flag("l").toString())
     System.setProperty(RUN_DDF_PROFILE, arguments.flag("ddf").toString())
 
-    if (arguments.flag("debug")) {
-        Log.logLevel = LogLevel.DEBUG
+    Log.logLevel = if (arguments.flag("debug")) {
+        LogLevel.DEBUG
     } else {
-        Log.logLevel = LogLevel.INFO
+        LogLevel.INFO
     }
 
-    launchTests()
+    TestRunner().launchTests()
 }
 
 private fun createParser(): Parser {
     return Parser().apply {
-        setName("SAML CTK")
-        setApplicationDescription("SAML Conformance Test Kit")
+        setName("SamlConf - Runs the SAML Conformance Tests against an IdP")
 
-        option("i", description = "Path to the implementation to be tested")
-        option("u", description = "User used to login in the format username:password.")
+        flag("ddf",
+                longOption = listOf("ddf"),
+                description = """Runs the DDF profile. If provided runs the optional SAML V2.0
+                    Standard Specification rules required by DDF."""
+        )
 
-        flag("debug", description = "Turn on debug logs.")
-        flag("ddf", description = """Run the DDF profile. If provided runs the optional
-            SAML V2.0 StandardSpecification rules required by DDF.""")
-        flag("l", description = """When an error occurs, the SAML V2.0 Standard
-            Specification requires an IdP to respond with a 200 HTTP status code and a valid SAML
-            response containing an error <StatusCode>. If the -l flag is given, this test kit will
-            allow HTTP error status codes as a valid error response.""")
-    }
-}
+        flag("debug",
+                longOption = listOf("debug"),
+                description = """Enables debug mode which enables more logging. This mode is off
+                        by default."""
+        )
 
-@Suppress("SpreadOperator")
-private fun launchTests() {
-    val request = LauncherDiscoveryRequestBuilder.request()
-            .selectors(*SSO_BASIC_TESTS,
-                    *SSO_ERROR_TESTS,
-                    *SLO_BASIC_TESTS,
-                    *SLO_ERROR_TESTS)
-            .build()
+        flag("h",
+                longOption = listOf("help"),
+                description = "Displays the possible arguments."
+        )
 
-    val summaryGeneratingListener = SummaryGeneratingListener()
-    LauncherFactory.create().apply {
-        registerTestExecutionListeners(summaryGeneratingListener, TestNameListener())
-    }.execute(request)
+        option("i",
+                longOption = listOf("implementation"),
+                description = """The path to the directory containing the implementation's
+                        plugin and metadata. The default value is /implementations/ddf."""
+        )
 
-    PrintWriter(System.out).use { printer ->
+        flag("l",
+                longOption = listOf("lenient"),
+                description = """When an error occurs, the SAML V2.0 Standard Specification
+                        requires an IdP to respond with a 200 HTTP status code and a valid SAML
+                        response containing an error <StatusCode>. If the -l flag is given, this
+                        test kit will allow HTTP error status codes as a valid error response
+                        (i.e. 400's and 500's). If it is not given, this test kit will only verify
+                        that a valid SAML error response is returned."""
+        )
 
-        summaryGeneratingListener.summary.printFailuresTo(printer)
-        summaryGeneratingListener.summary.printTo(printer)
-
-        if (summaryGeneratingListener.summary.totalFailureCount > 0) {
-            System.out.println(ansi().fgRed().a("TESTS FAILED").reset())
-            System.exit(1)
-        }
-
-        printer.println(ansi().fgGreen().a("TESTS PASSED").reset())
-    }
-}
-
-private class TestNameListener : TestExecutionListener {
-    override fun testPlanExecutionStarted(testPlan: TestPlan?) {
-        System.out.apply {
-            println()
-            println("----------------------------------")
-            println("SAML Conformance Test Kit Starting")
-            println("----------------------------------")
-        }
-    }
-
-    override fun executionFinished(
-        testIdentifier: TestIdentifier,
-        testExecutionResult: TestExecutionResult
-    ) {
-        if (testIdentifier.isTest)
-            System.out.println(
-                    "${testIdentifier.displayName} ${getResultDisplay(testExecutionResult.status)}")
-    }
-
-    private fun getResultDisplay(status: TestExecutionResult.Status): Any {
-        return when (status) {
-            TestExecutionResult.Status.SUCCESSFUL -> ansi().fgGreen().a(status.name).reset()
-            TestExecutionResult.Status.FAILED -> ansi().fgRed().a(status.name).reset()
-            else -> status.name
-        }
+        option("u",
+                longOption = listOf("userLogin"),
+                description = """The username and password to use when logging in. The default
+                        value is admin:admin."""
+        )
     }
 }

--- a/deployment/distribution/src/main/kotlin/org/codice/ctk/TestRunner.kt
+++ b/deployment/distribution/src/main/kotlin/org/codice/ctk/TestRunner.kt
@@ -1,0 +1,99 @@
+/*
+Copyright (c) 2018 Codice Foundation
+
+Released under the GNU Lesser General Public License; see
+http://www.gnu.org/licenses/lgpl.html
+*/
+package org.codice.ctk
+
+import org.codice.compliance.web.slo.PostSLOTest
+import org.codice.compliance.web.slo.RedirectSLOTest
+import org.codice.compliance.web.slo.error.PostSLOErrorTest
+import org.codice.compliance.web.slo.error.RedirectSLOErrorTest
+import org.codice.compliance.web.sso.PostSSOTest
+import org.codice.compliance.web.sso.RedirectSSOTest
+import org.codice.compliance.web.sso.error.PostSSOErrorTest
+import org.codice.compliance.web.sso.error.RedirectSSOErrorTest
+import org.fusesource.jansi.Ansi
+import org.junit.platform.engine.TestExecutionResult
+import org.junit.platform.engine.discovery.DiscoverySelectors.selectClass
+import org.junit.platform.launcher.TestExecutionListener
+import org.junit.platform.launcher.TestIdentifier
+import org.junit.platform.launcher.TestPlan
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder
+import org.junit.platform.launcher.core.LauncherFactory
+import org.junit.platform.launcher.listeners.SummaryGeneratingListener
+import java.io.PrintWriter
+
+internal class TestRunner {
+    private class Runner {
+        companion object {
+            val TESTS = arrayOf(
+                    selectClass(PostSSOTest::class.java),
+                    selectClass(PostSSOErrorTest::class.java),
+                    selectClass(PostSLOTest::class.java),
+                    selectClass(PostSLOErrorTest::class.java),
+                    selectClass(RedirectSSOTest::class.java),
+                    selectClass(RedirectSSOErrorTest::class.java),
+                    selectClass(RedirectSLOTest::class.java),
+                    selectClass(RedirectSLOErrorTest::class.java)
+            )
+        }
+    }
+
+    @Suppress("SpreadOperator")
+    internal fun launchTests() {
+        val request = LauncherDiscoveryRequestBuilder.request()
+                .selectors(*Runner.TESTS)
+                .build()
+
+        val summaryGeneratingListener = SummaryGeneratingListener()
+        LauncherFactory.create().apply {
+            registerTestExecutionListeners(summaryGeneratingListener, TestNameListener())
+        }.execute(request)
+
+        PrintWriter(System.out).use { printer ->
+
+            summaryGeneratingListener.summary.printFailuresTo(printer)
+            summaryGeneratingListener.summary.printTo(printer)
+
+            if (summaryGeneratingListener.summary.totalFailureCount > 0) {
+                System.out.println(Ansi.ansi().fgRed().a("TESTS FAILED").reset())
+                System.exit(1)
+            }
+
+            printer.println(Ansi.ansi().fgGreen().a("TESTS PASSED").reset())
+        }
+    }
+
+    private class TestNameListener : TestExecutionListener {
+        override fun testPlanExecutionStarted(testPlan: TestPlan?) {
+            System.out.apply {
+                println()
+                println("----------------------------------")
+                println("SAML Conformance Test Kit Starting")
+                println("----------------------------------")
+            }
+        }
+
+        override fun executionFinished(
+            testIdentifier: TestIdentifier,
+            testExecutionResult: TestExecutionResult
+        ) {
+            if (testIdentifier.isTest)
+                System.out.println(
+                        """${testIdentifier.displayName}
+                            ${getResultDisplay(testExecutionResult.status)}""")
+        }
+
+        private fun getResultDisplay(status: TestExecutionResult.Status): Any {
+            return when (status) {
+                TestExecutionResult.Status.SUCCESSFUL ->
+                    Ansi.ansi().fgGreen().a(status.name).reset()
+                TestExecutionResult.Status.FAILED ->
+                    Ansi.ansi().fgRed().a(status.name).reset()
+                else -> status.name
+            }
+        }
+    }
+}

--- a/deployment/distribution/src/main/resources/README.md
+++ b/deployment/distribution/src/main/resources/README.md
@@ -32,34 +32,34 @@ How to Run
 The `samlconf` script may take the following parameters:
 
     NAME
-           samlconf - Runs the SAML Conformance Tests against an IdP
+           SamlConf - Runs the SAML Conformance Tests against an IdP
 
     SYNOPSIS
            samlconf [arguments ...]
 
     DESCRIPTION
-           Runs the SAML Conformance Tests which test the compliance of an IdP
-           to the SAML Specifications. If a compliance issue is identified, a
-           SAMLComplianceException will be thrown with an explanation of the error and a direct
-           quote from the specification. Tests will not run if the corresponding
-           endpoints do not exist in the IdP's metadata. All of the parameters
-           are optional and if they are not provided, the default values will use
-           Distributed Data Framework (DDF)'s parameters. See the README.md file at
-           https://github.com/codice/ddf to learn more about DDF.
+           Runs the SAML Conformance Tests which test the compliance of an IdP with the SAML Specifications.
+           If a compliance issue is identified, a SAMLComplianceException will be thrown with an explanation
+           of the error and a direct quote from the specification. Tests will not run if the corresponding
+           endpoints do not exist in the IdP's metadata. All of the parameters are optional and if they are
+           not provided, the default values will use Distributed Data Framework (DDF)'s parameters.
 
     OPTIONS
-           -debug
-                Enables debug mode which enables more logging. This mode is off by default.
-
-           -ddf
+           -ddf, --ddf
                 Runs the DDF profile. If provided runs the optional SAML V2.0 Standard
                 Specification rules required by DDF.
 
-           -i path
+           -debug, --debug
+                Enables debug mode which enables more logging. This mode is off by default.
+
+           -h, --help
+		        Displays the possible arguments.
+
+           -i path, --implementation=path
                 The path to the directory containing the implementation's plugin and metadata.
                 The default value is /implementations/ddf.
 
-           -l
+           -l, --lenient
                 When an error occurs, the SAML V2.0 Standard Specification requires an IdP to
                 respond with a 200 HTTP status code and a valid SAML response containing an
                 error <StatusCode>.
@@ -68,7 +68,7 @@ The `samlconf` script may take the following parameters:
                 If it is not given, this test kit will only verify that a valid SAML error
                 response is returned.
 
-           -u username:password
+           -u username:password, --userLogin=username:password
                 The username and password to use when logging in.
                 The default value is admin:admin.
 

--- a/external/implementations/samlconf-ddf-impl/src/main/resources/ddf-idp-metadata.xml
+++ b/external/implementations/samlconf-ddf-impl/src/main/resources/ddf-idp-metadata.xml
@@ -1,4 +1,4 @@
-<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" cacheDuration="P7DT0H0M0.000S" entityID="https://localhost:32781/ddf/services/idp/login">
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" cacheDuration="P7DT0H0M0.000S" entityID="https://localhost:8993/services/idp/login">
     <md:IDPSSODescriptor WantAuthnRequestsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
         <md:KeyDescriptor use="signing">
             <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
@@ -18,9 +18,9 @@
                 </ds:X509Data>
             </ds:KeyInfo>
         </md:KeyDescriptor>
-        <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://localhost:32781/ddf/services/idp/logout"/>
-        <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://localhost:32781/ddf/services/idp/logout"/>
-        <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://localhost:32781/ddf/services/idp/logout"/>
+        <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://localhost:8993/services/idp/logout"/>
+        <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://localhost:8993/services/idp/logout"/>
+        <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://localhost:8993/services/idp/logout"/>
         <md:NameIDFormat>
             urn:oasis:names:tc:SAML:2.0:nameid-format:persistent
         </md:NameIDFormat>
@@ -30,8 +30,8 @@
         <md:NameIDFormat>
             urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName
         </md:NameIDFormat>
-        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://localhost:32781/ddf/services/idp/login"/>
-        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://localhost:32781/ddf/services/idp/login"/>
-        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://localhost:32781/ddf/services/idp/login"/>
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://localhost:8993/services/idp/login"/>
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://localhost:8993/services/idp/login"/>
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://localhost:8993/services/idp/login"/>
     </md:IDPSSODescriptor>
 </md:EntityDescriptor>

--- a/external/implementations/samlconf-ddf-impl/src/main/resources/ddf-idp-metadata.xml
+++ b/external/implementations/samlconf-ddf-impl/src/main/resources/ddf-idp-metadata.xml
@@ -1,4 +1,4 @@
-<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" cacheDuration="P7DT0H0M0.000S" entityID="https://localhost:8993/services/idp/login">
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" cacheDuration="P7DT0H0M0.000S" entityID="https://localhost:32781/ddf/services/idp/login">
     <md:IDPSSODescriptor WantAuthnRequestsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
         <md:KeyDescriptor use="signing">
             <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
@@ -18,9 +18,9 @@
                 </ds:X509Data>
             </ds:KeyInfo>
         </md:KeyDescriptor>
-        <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://localhost:8993/services/idp/logout"/>
-        <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://localhost:8993/services/idp/logout"/>
-        <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://localhost:8993/services/idp/logout"/>
+        <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://localhost:32781/ddf/services/idp/logout"/>
+        <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://localhost:32781/ddf/services/idp/logout"/>
+        <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://localhost:32781/ddf/services/idp/logout"/>
         <md:NameIDFormat>
             urn:oasis:names:tc:SAML:2.0:nameid-format:persistent
         </md:NameIDFormat>
@@ -30,8 +30,8 @@
         <md:NameIDFormat>
             urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName
         </md:NameIDFormat>
-        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://localhost:8993/services/idp/login"/>
-        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://localhost:8993/services/idp/login"/>
-        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://localhost:8993/services/idp/login"/>
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://localhost:32781/ddf/services/idp/login"/>
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://localhost:32781/ddf/services/idp/login"/>
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://localhost:32781/ddf/services/idp/login"/>
     </md:IDPSSODescriptor>
 </md:EntityDescriptor>


### PR DESCRIPTION
### Description of the Change
- Added a help option and extracted the test running into its own class.
- Added javadoc to the RestAssuredExtensions class and a check that the response body is not null if the binding is not redirect.

See: https://github.com/codice/saml-conformance/issues/209

![screen shot 2018-12-17 at 10 25 21 am](https://user-images.githubusercontent.com/29550062/50103966-236d9200-01e6-11e9-8f10-75d259107ee7.png)

### SAML V2.0 Specification Quote
N/A

### Verification Process
`./samlconf --help` displays the script options 

### Checklist:
- [ ] Unit Tests Added/Modified
