### PR TITLE
[MAINT] Change DDF and Keycloak to use given username instead of the default one.

### DIFF
--- a/ctk/common/src/main/kotlin/org/codice/compliance/utils/TestCommon.kt
+++ b/ctk/common/src/main/kotlin/org/codice/compliance/utils/TestCommon.kt
@@ -13,8 +13,8 @@ import org.apache.wss4j.common.saml.OpenSAMLUtil
 import org.apache.wss4j.common.util.DOM2Writer
 import org.codice.compliance.Common.Companion.idpMetadataObject
 import org.codice.compliance.Common.Companion.parseSpMetadata
-import org.codice.compliance.IMPLEMENTATION_PATH
 import org.codice.compliance.DecoratedNode
+import org.codice.compliance.IMPLEMENTATION_PATH
 import org.codice.compliance.SAMLComplianceException
 import org.codice.compliance.SAMLGeneral_c
 import org.codice.compliance.USER_LOGIN
@@ -60,6 +60,10 @@ class TestCommon {
 
         val username by lazy {
             System.getProperty(USER_LOGIN).split(":").first()
+        }
+
+        val password by lazy {
+            System.getProperty(USER_LOGIN).split(":").last()
         }
 
         val idpMetadata by lazy {

--- a/deployment/distribution/src/main/kotlin/org/codice/ctk/Command.kt
+++ b/deployment/distribution/src/main/kotlin/org/codice/ctk/Command.kt
@@ -29,7 +29,11 @@ fun main(args: Array<String>) {
     val arguments = parser.parse(args)
 
     val implementationPath = arguments.option("i") ?: defaultImplPath
-    val userLogin = arguments.option("u") ?: "admin:admin"
+    var userLogin = arguments.option("u") ?: "admin:admin"
+    if (userLogin.split(":").size != 2) {
+        Log.error("Given username and password $userLogin is invalid. Using admin:admin instead.")
+        userLogin = "admin:admin"
+    }
 
     if (arguments.flag("help")) {
         println(parser.printHelp())

--- a/external/implementations/samlconf-ddf-impl/README.md
+++ b/external/implementations/samlconf-ddf-impl/README.md
@@ -11,8 +11,6 @@ http://www.gnu.org/licenses/lgpl.html
 | ---------------------------------------------------------------------------------------------------------------------- | ---------------- | -----------------------
 | Does not respond with SAML error responses with a top­level status code but throws an exception instead.| Core 3.4.1.4 | If the responder is unable to authenticate the presenter or does not recognize the requested subject, or if prevented from providing an assertion by policies in effect at the identity provider (for example the intended subject has prohibited the identity provider from providing assertions to the relying party), then it MUST return a `<Response>` with an error `<Status>`.
 | When the IdP is issuing LogoutRequests to SPs, the `NameID` is missing all of its XML attributes. | Profiles 4.4.4.1 | The principal MUST be identified in the request using an identifier that strongly matches the identifier in the authentication assertion the requester issued or received regarding the session being terminated, per the matching rules defined in Section 3.3.4 of SAMLCore.
-| The IdP ignores the `<Subject>` element on the `<AuthnRequest>` instead of validating it. | Profiles 4.1.4.1 | Note that the service provider MAY include a `<Subject>` element in the request that names the actual identity about which it wishes to receive an assertion. This element MUST NOT contain any `<SubjectConfirmation>` elements. If the identity provider does not recognize the principal as that identity, then it MUST respond with a `<Response>` message containing an error status and no assertions.
-
 
 ## Steps to Test DDF's IDP
 * Start and install DDF. \

--- a/external/implementations/samlconf-ddf-impl/build.gradle.kts
+++ b/external/implementations/samlconf-ddf-impl/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     compile(Libs.cxfSsoSaml)
 
     compile(project(":external:samlconf-plugins-api"))
+    compile(project(":ctk:common"))
 
     kapt(Libs.kaptMetainfService)
 }

--- a/external/implementations/samlconf-ddf-impl/src/main/kotlin/org/codice/compliance/saml/plugin/ddf/DDFIdpSSOResponderProvider.kt
+++ b/external/implementations/samlconf-ddf-impl/src/main/kotlin/org/codice/compliance/saml/plugin/ddf/DDFIdpSSOResponderProvider.kt
@@ -13,6 +13,8 @@ import io.restassured.builder.RequestSpecBuilder
 import io.restassured.response.Response
 import org.codice.compliance.Common
 import org.codice.compliance.saml.plugin.IdpSSOResponder
+import org.codice.compliance.utils.TestCommon.Companion.password
+import org.codice.compliance.utils.TestCommon.Companion.username
 import org.codice.security.saml.SamlProtocol
 import org.kohsuke.MetaInfServices
 
@@ -53,7 +55,7 @@ class DDFIdpSSOResponderProvider : IdpSSOResponder {
                 .given(requestSpec)
                 .auth()
                 .preemptive()
-                .basic("admin", "admin")
+                .basic(username, password)
                 .log()
                 .ifValidationFails()
                 .`when`()

--- a/external/implementations/samlconf-keycloak-impl/build.gradle.kts
+++ b/external/implementations/samlconf-keycloak-impl/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     compile(Libs.cxfSsoSaml)
 
     compile(project(":external:samlconf-plugins-api"))
+    compile(project(":ctk:common"))
 
     kapt(Libs.kaptMetainfService)
 }

--- a/external/implementations/samlconf-keycloak-impl/src/main/kotlin/org/codice/compliance/saml/plugin/keycloak/KeycloakIdpSSOResponderProvider.kt
+++ b/external/implementations/samlconf-keycloak-impl/src/main/kotlin/org/codice/compliance/saml/plugin/keycloak/KeycloakIdpSSOResponderProvider.kt
@@ -9,6 +9,8 @@ package org.codice.compliance.saml.plugin.keycloak
 import io.restassured.RestAssured
 import io.restassured.response.Response
 import org.codice.compliance.saml.plugin.IdpSSOResponder
+import org.codice.compliance.utils.TestCommon.Companion.password
+import org.codice.compliance.utils.TestCommon.Companion.username
 import org.kohsuke.MetaInfServices
 
 @MetaInfServices
@@ -44,7 +46,7 @@ class KeycloakIdpSSOResponderProvider : IdpSSOResponder {
         return RestAssured.given()
                 .urlEncodingEnabled(false)
                 .cookies(cookies)
-                .body("username=admin&password=admin")
+                .body("username=$username&password=$password")
                 .contentType("application/x-www-form-urlencoded")
                 .log()
                 .ifValidationFails()


### PR DESCRIPTION
### Description of the Change
- Changes the DDF and Keycloak plugins to use the given username instead of the default one.
- Deletes the "<Subject>'s name id" issue from DDF's compliance issues that was fixed by @bakejeyner 

### SAML V2.0 Specification Quote
N/A

### Verification Process
- Make sure that the given username and password by -u is used when logging in in the plugin for Keycloak and DDF. If one is not given the default admin/admin should be used.

### Checklist:
- [ ] Unit Tests Added/Modified
